### PR TITLE
Touch screen related bug-fix

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -279,7 +279,8 @@ Main components
   height: 100%;
   width: 100%;
   overflow: auto;
-  -webkit-overflow-scrolling: touch;
+  /* On iPhones prevents page scrolling */
+  /* -webkit-overflow-scrolling: touch; */
 }
 .cd-testimonials-all .cd-testimonials-all-wrapper > ul {
   width: 90%;


### PR DESCRIPTION
commented out `-webkit-overflow-scrolling: touch;` prevents page from scrolling on touch devices, tested on iPhone.
